### PR TITLE
remove duplicate foamtree script reference

### DIFF
--- a/output/index.html
+++ b/output/index.html
@@ -1,5 +1,4 @@
 <!-- largely stollen from: https://github.com/th0r/webpack-bundle-analyzer -->
-<script src="_assets/foamtree-3.4.4/carrotsearch.foamtree.js"></script>
 <script src="_assets/tooltip.js"></script>
 <body>
 


### PR DESCRIPTION
Looks like this was an extra reference since its already: https://github.com/stefanpenner/broccoli-concat-analyser/blob/master/output/index.html#L29

Also ```_assets/foamtree-3.4.4/``` is not in the repo