### PR TITLE
Fix missing src folder in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+test
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.travis.yml
+.gitignore

--- a/package.json
+++ b/package.json
@@ -15,14 +15,6 @@
   },
   "author": "",
   "license": "ISC",
-  "files": [
-    "build-output-summary.js",
-    "index.js",
-    "output/index.html",
-    "output/_assets/carrotsearch.foamtree.js",
-    "output/_assets/filesize.js",
-    "output/_assets/tooltip.js"
-  ],
   "bugs": {
     "url": "https://github.com/stefanpenner/broccoli-concat-analyser/issues"
   },


### PR DESCRIPTION
I broke the npm package! 🎉

`package.json` had a `files` key that I missed, so the whole `src` folder was missing in the npm package! 😬

Btw, was just wondering if we should rename `src` to `lib`, to follow conventions? (remember people stating that `src` should be used for things that are built to `dist`)