### PR TITLE
Fix uglified size

### DIFF
--- a/lib/amend-group-stats.js
+++ b/lib/amend-group-stats.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const filesize = require('filesize');
-const getTotal = require('./get-total');
+const getTotalHash = require('./get-total-hash');
 
 /**
  * Add `sizes` and `weight` meta data to the given group, based on its child groups/files
@@ -22,12 +22,10 @@ module.exports = function amendGroupStats(group, totalSize) {
       throw new Error('Group has no children');
     }
     group.groups.forEach(group => amendGroupStats(group, totalSize));
-    groupTotal = getTotal(group.groups);
-    group.sizes = {
-      raw: getTotal(group.groups, 'raw'),
-      uglified: getTotal(group.groups, 'uglified'),
-      compressed: groupTotal
-    };
+
+    let sizes = getTotalHash(group.groups);
+    groupTotal = sizes.compressed;
+    group.sizes = sizes;
   }
 
   group.label += ` (${filesize(groupTotal)})`;

--- a/lib/get-total-hash.js
+++ b/lib/get-total-hash.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const getTotal = require('./get-total');
+
+const sizeKeys = ['raw', 'uglified', 'compressed'];
+
+module.exports = function getTotalHash(files) {
+  let sizes = {};
+  sizeKeys.forEach((key) => {
+    let total = getTotal(files, key);
+    if (!isNaN(total)) {
+      sizes[key] = total;
+    }
+  });
+  return sizes;
+}

--- a/lib/process-data.js
+++ b/lib/process-data.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const filesize = require('filesize');
-const getTotal = require('./get-total');
+const getTotalHash = require('./get-total-hash');
 const groupFiles = require('./group-files');
 const amendGroupStats = require('./amend-group-stats');
 
@@ -12,7 +12,8 @@ const amendGroupStats = require('./amend-group-stats');
  * @returns {{label: string, groups: groups, sizes: {raw, uglified, compressed}}}
  */
 module.exports = function processData(outJson) {
-  let total = getTotal(outJson.files, 'compressed');
+  let sizes = getTotalHash(outJson.files);
+  let total = sizes.compressed;
   let groups = groupFiles(outJson.files);
   groups.forEach(group => amendGroupStats(group, total));
 
@@ -20,10 +21,6 @@ module.exports = function processData(outJson) {
   return {
     label: `${label} (${filesize(total)})`,
     groups,
-    sizes: {
-      raw: getTotal(outJson.files, 'raw'),
-      uglified: getTotal(outJson.files, 'uglified'),
-      compressed: total
-    }
+    sizes
   };
 };

--- a/lib/summarize.js
+++ b/lib/summarize.js
@@ -42,24 +42,21 @@ module.exports = function summarize(summaryPath) {
 
   let files = fileNames.map(relativePath => {
     let content = fileContents[relativePath];
-    let uglified, compressed;
+    let sizes = {
+      raw: content.length
+    };
 
     // assume the proportion of the compressed size is roughly the same as of the uglified/raw size
     if (isUglifyable) {
-      uglified = Uglify.minify(content).code.length;
-      compressed = uglified / baseSize * compressedSize;
+      sizes.uglified = Uglify.minify(content).code.length;
+      sizes.compressed = sizes.uglified / baseSize * compressedSize;
     } else {
-      uglified = 'N/A';
-      compressed = content.length / baseSize * compressedSize;
+      sizes.compressed = content.length / baseSize * compressedSize;
     }
 
     return {
       relativePath,
-      sizes: {
-        raw: content.length,
-        uglified,
-        compressed
-      }
+      sizes
     }
   });
 

--- a/output/index.html
+++ b/output/index.html
@@ -34,8 +34,8 @@ html, body, .visualization {
   window.addEventListener('load', function() {
     Tooltip.init();
 
-    function filesizeOrNan(size) {
-      if (isNaN(size)) {
+    function formatSize(size) {
+      if (size === undefined || isNaN(size)) {
         return 'N/A';
       } else {
         return filesize(size);
@@ -80,9 +80,9 @@ html, body, .visualization {
         if (group) {
           Tooltip.show(
               '<b>' +          group.label + '</b><br>' +
-              'raw: ' +        filesizeOrNan(group.sizes.raw) + ' <br> ' +
-              'uglified: ' +   filesizeOrNan(group.sizes.uglified) + ' <br> ' +
-              'compressed: ' + filesizeOrNan(group.sizes.compressed) + ' <br> '
+              'raw: ' +        formatSize(group.sizes.raw) + ' <br> ' +
+              'uglified: ' +   formatSize(group.sizes.uglified) + ' <br> ' +
+              'compressed: ' + formatSize(group.sizes.compressed) + ' <br> '
               );
         } else {
           Tooltip.hide();

--- a/test/fixtures/output/8-test-support.css.out.json
+++ b/test/fixtures/output/8-test-support.css.out.json
@@ -5,7 +5,6 @@
       "relativePath": "vendor/qunit/qunit.css",
       "sizes": {
         "raw": 7875,
-        "uglified": "N/A",
         "compressed": 2123.0700712589073
       }
     },
@@ -13,7 +12,6 @@
       "relativePath": "vendor/ember-qunit/test-container-styles.css",
       "sizes": {
         "raw": 544,
-        "uglified": "N/A",
         "compressed": 146.6603325415677
       }
     }

--- a/test/fixtures/output/build-output-summary.json
+++ b/test/fixtures/output/build-output-summary.json
@@ -129,7 +129,6 @@
                 {
                   "sizes": {
                     "raw": 7875,
-                    "uglified": "N/A",
                     "compressed": 2123.0700712589073
                   },
                   "label": "qunit.css (2.07 KB)",
@@ -138,7 +137,6 @@
               ],
               "sizes": {
                 "raw": 7875,
-                "uglified": "N/A0",
                 "compressed": 2123.0700712589073
               },
               "weight": 0.9353842499109158
@@ -149,7 +147,6 @@
                 {
                   "sizes": {
                     "raw": 544,
-                    "uglified": "N/A",
                     "compressed": 146.6603325415677
                   },
                   "label": "test-container-styles.css (147 B)",
@@ -158,7 +155,6 @@
               ],
               "sizes": {
                 "raw": 544,
-                "uglified": "N/A0",
                 "compressed": 146.6603325415677
               },
               "weight": 0.06461575008908421
@@ -166,7 +162,6 @@
           ],
           "sizes": {
             "raw": 8419,
-            "uglified": "N/A0N/A00",
             "compressed": 2269.730403800475
           },
           "weight": 1
@@ -174,7 +169,6 @@
       ],
       "sizes": {
         "raw": 8419,
-        "uglified": "N/AN/A0",
         "compressed": 2269.730403800475
       },
       "rank": 0.7367507396948698

--- a/test/fixtures/output/summary.js
+++ b/test/fixtures/output/summary.js
@@ -129,7 +129,6 @@
                 {
                   "sizes": {
                     "raw": 7875,
-                    "uglified": "N/A",
                     "compressed": 2123.0700712589073
                   },
                   "label": "qunit.css (2.07 KB)",
@@ -138,7 +137,6 @@
               ],
               "sizes": {
                 "raw": 7875,
-                "uglified": "N/A0",
                 "compressed": 2123.0700712589073
               },
               "weight": 0.9353842499109158
@@ -149,7 +147,6 @@
                 {
                   "sizes": {
                     "raw": 544,
-                    "uglified": "N/A",
                     "compressed": 146.6603325415677
                   },
                   "label": "test-container-styles.css (147 B)",
@@ -158,7 +155,6 @@
               ],
               "sizes": {
                 "raw": 544,
-                "uglified": "N/A0",
                 "compressed": 146.6603325415677
               },
               "weight": 0.06461575008908421
@@ -166,7 +162,6 @@
           ],
           "sizes": {
             "raw": 8419,
-            "uglified": "N/A0N/A00",
             "compressed": 2269.730403800475
           },
           "weight": 1
@@ -174,7 +169,6 @@
       ],
       "sizes": {
         "raw": 8419,
-        "uglified": "N/AN/A0",
         "compressed": 2269.730403800475
       },
       "rank": 0.7367507396948698

--- a/test/unit/get-total-test.js
+++ b/test/unit/get-total-test.js
@@ -26,7 +26,7 @@ describe('get-total', function() {
     expect(getTotal(files)).to.equal(1570);
   });
 
-  it('gets any total size of all files', function() {
+  it('gets total raw size of all files', function() {
     let files = [
       {
         sizes: {
@@ -45,6 +45,25 @@ describe('get-total', function() {
     ];
 
     expect(getTotal(files, 'raw')).to.equal(8100);
+  });
+
+  it('ignores non-existing size key', function() {
+    let files = [
+      {
+        sizes: {
+          raw: 100,
+          compressed: 70
+        }
+      },
+      {
+        sizes: {
+          raw: 8000,
+          compressed: 1500
+        }
+      }
+    ];
+
+    expect(getTotal(files, 'uglified')).to.be.NaN;
   });
 
 });


### PR DESCRIPTION
Total sizes that are not available (i.e. `uglified` for non-JS assets) are left out of the intermediate JSON files, the human-friendly formatting of "N/A" is applied only at the final "view layer", i.e. index.html

Fixes #21