### PR TITLE
Fix invalid concatenation

### DIFF
--- a/lib/summarize.js
+++ b/lib/summarize.js
@@ -24,7 +24,9 @@ module.exports = function summarize(summaryPath) {
   // at compressing the whole bundle
   // @todo This could be avoided if broccoli-concat would give us the concatenated file it has created, but the `outputFile`
   // is currently a temporary file, which does not exist anymore when we run this, so we have to recreate it
-  let concatenatedContent = Object.keys(fileContents).reduce((result, filename) => result + fileContents[filename], '');
+  let concatenatedContent = Object.keys(fileContents)
+    .map(filename => fileContents[filename])
+    .join('\n');
   let compressed, baseSize;
   let isUglifyable = /\.js$/.test(input.outputFile);
 

--- a/test/fixtures/input/1-test-app.js/test-app/initializers/app-version.js
+++ b/test/fixtures/input/1-test-app.js/test-app/initializers/app-version.js
@@ -11,4 +11,5 @@ define('test-app/initializers/app-version', ['exports', 'ember-cli-app-version/i
     name: 'App Version',
     initialize: (0, _initializerFactory.default)(name, version)
   };
-});
+
+})

--- a/test/fixtures/output/8-test-support.css.out.json
+++ b/test/fixtures/output/8-test-support.css.out.json
@@ -6,7 +6,7 @@
       "sizes": {
         "raw": 7875,
         "uglified": "N/A",
-        "compressed": 2126.1284000475116
+        "compressed": 2123.0700712589073
       }
     },
     {
@@ -14,7 +14,7 @@
       "sizes": {
         "raw": 544,
         "uglified": "N/A",
-        "compressed": 146.87159995248842
+        "compressed": 146.6603325415677
       }
     }
   ]

--- a/test/fixtures/output/build-output-summary.json
+++ b/test/fixtures/output/build-output-summary.json
@@ -105,7 +105,7 @@
         "uglified": 2538,
         "compressed": 810.9999999999999
       },
-      "rank": 0.2629701686121919
+      "rank": 0.26324926030513013
     },
     {
       "label": "/assets/vendor.css (0 B)",
@@ -124,22 +124,22 @@
           "label": "vendor (2.22 KB)",
           "groups": [
             {
-              "label": "qunit (2.08 KB)",
+              "label": "qunit (2.07 KB)",
               "groups": [
                 {
                   "sizes": {
                     "raw": 7875,
                     "uglified": "N/A",
-                    "compressed": 2126.1284000475116
+                    "compressed": 2123.0700712589073
                   },
-                  "label": "qunit.css (2.08 KB)",
+                  "label": "qunit.css (2.07 KB)",
                   "weight": 0.9353842499109158
                 }
               ],
               "sizes": {
                 "raw": 7875,
                 "uglified": "N/A0",
-                "compressed": 2126.1284000475116
+                "compressed": 2123.0700712589073
               },
               "weight": 0.9353842499109158
             },
@@ -150,7 +150,7 @@
                   "sizes": {
                     "raw": 544,
                     "uglified": "N/A",
-                    "compressed": 146.87159995248842
+                    "compressed": 146.6603325415677
                   },
                   "label": "test-container-styles.css (147 B)",
                   "weight": 0.06461575008908421
@@ -159,7 +159,7 @@
               "sizes": {
                 "raw": 544,
                 "uglified": "N/A0",
-                "compressed": 146.87159995248842
+                "compressed": 146.6603325415677
               },
               "weight": 0.06461575008908421
             }
@@ -167,7 +167,7 @@
           "sizes": {
             "raw": 8419,
             "uglified": "N/A0N/A00",
-            "compressed": 2273
+            "compressed": 2269.730403800475
           },
           "weight": 1
         }
@@ -175,9 +175,9 @@
       "sizes": {
         "raw": 8419,
         "uglified": "N/AN/A0",
-        "compressed": 2273
+        "compressed": 2269.730403800475
       },
-      "rank": 0.7370298313878081
+      "rank": 0.7367507396948698
     }
   ]
 }

--- a/test/fixtures/output/summary.js
+++ b/test/fixtures/output/summary.js
@@ -105,7 +105,7 @@
         "uglified": 2538,
         "compressed": 810.9999999999999
       },
-      "rank": 0.2629701686121919
+      "rank": 0.26324926030513013
     },
     {
       "label": "/assets/vendor.css (0 B)",
@@ -124,22 +124,22 @@
           "label": "vendor (2.22 KB)",
           "groups": [
             {
-              "label": "qunit (2.08 KB)",
+              "label": "qunit (2.07 KB)",
               "groups": [
                 {
                   "sizes": {
                     "raw": 7875,
                     "uglified": "N/A",
-                    "compressed": 2126.1284000475116
+                    "compressed": 2123.0700712589073
                   },
-                  "label": "qunit.css (2.08 KB)",
+                  "label": "qunit.css (2.07 KB)",
                   "weight": 0.9353842499109158
                 }
               ],
               "sizes": {
                 "raw": 7875,
                 "uglified": "N/A0",
-                "compressed": 2126.1284000475116
+                "compressed": 2123.0700712589073
               },
               "weight": 0.9353842499109158
             },
@@ -150,7 +150,7 @@
                   "sizes": {
                     "raw": 544,
                     "uglified": "N/A",
-                    "compressed": 146.87159995248842
+                    "compressed": 146.6603325415677
                   },
                   "label": "test-container-styles.css (147 B)",
                   "weight": 0.06461575008908421
@@ -159,7 +159,7 @@
               "sizes": {
                 "raw": 544,
                 "uglified": "N/A0",
-                "compressed": 146.87159995248842
+                "compressed": 146.6603325415677
               },
               "weight": 0.06461575008908421
             }
@@ -167,7 +167,7 @@
           "sizes": {
             "raw": 8419,
             "uglified": "N/A0N/A00",
-            "compressed": 2273
+            "compressed": 2269.730403800475
           },
           "weight": 1
         }
@@ -175,9 +175,9 @@
       "sizes": {
         "raw": 8419,
         "uglified": "N/AN/A0",
-        "compressed": 2273
+        "compressed": 2269.730403800475
       },
-      "rank": 0.7370298313878081
+      "rank": 0.7367507396948698
     }
   ]
 }


### PR DESCRIPTION
Uglify would throw when some file was terminated incorrectly without a semicolon or newline. Regression was introduced in #20.