### PR TITLE
Proportional weight

### DIFF
--- a/lib/amend-group-stats.js
+++ b/lib/amend-group-stats.js
@@ -29,5 +29,5 @@ module.exports = function amendGroupStats(group, totalSize) {
   }
 
   group.label += ` (${filesize(groupTotal)})`;
-  group.weight = groupTotal / totalSize;
+  group.weight = groupTotal;
 };

--- a/lib/build-output-summary.js
+++ b/lib/build-output-summary.js
@@ -5,8 +5,7 @@ const path = require('path');
 const processData = require('./process-data');
 
 function rank(entries) {
-  let total = entries.reduce((sum, entry) => entry.sizes.compressed + sum, 0);
-  entries.forEach(entry => entry.rank = (entry.sizes.compressed / total));
+  entries.forEach(entry => entry.weight = entry.sizes.compressed);
   return entries;
 }
 

--- a/test/fixtures/output/build-output-summary.json
+++ b/test/fixtures/output/build-output-summary.json
@@ -13,7 +13,7 @@
                 "compressed": 119.82860520094562
               },
               "label": "app.js (120 B)",
-              "weight": 0.14775413711583926
+              "weight": 119.82860520094562
             },
             {
               "label": "initializers (455 B)",
@@ -25,7 +25,7 @@
                     "compressed": 99.37785657998424
                   },
                   "label": "app-version.js (99 B)",
-                  "weight": 0.12253743104806937
+                  "weight": 99.37785657998424
                 },
                 {
                   "sizes": {
@@ -34,7 +34,7 @@
                     "compressed": 136.76438140267928
                   },
                   "label": "container-debug-adapter.js (137 B)",
-                  "weight": 0.1686367218282112
+                  "weight": 136.76438140267928
                 },
                 {
                   "sizes": {
@@ -43,7 +43,7 @@
                     "compressed": 218.56737588652481
                   },
                   "label": "export-application-global.js (219 B)",
-                  "weight": 0.2695035460992908
+                  "weight": 218.56737588652481
                 }
               ],
               "sizes": {
@@ -51,7 +51,7 @@
                 "uglified": 1423,
                 "compressed": 454.70961386918833
               },
-              "weight": 0.5606776989755714
+              "weight": 454.70961386918833
             },
             {
               "sizes": {
@@ -60,7 +60,7 @@
                 "compressed": 49.20961386918834
               },
               "label": "resolver.js (49 B)",
-              "weight": 0.06067769897557133
+              "weight": 49.20961386918834
             },
             {
               "sizes": {
@@ -69,7 +69,7 @@
                 "compressed": 84.35933806146572
               },
               "label": "router.js (84 B)",
-              "weight": 0.10401891252955084
+              "weight": 84.35933806146572
             },
             {
               "label": "templates (103 B)",
@@ -81,7 +81,7 @@
                     "compressed": 102.89282899921197
                   },
                   "label": "application.js (103 B)",
-                  "weight": 0.1268715524034673
+                  "weight": 102.89282899921197
                 }
               ],
               "sizes": {
@@ -89,7 +89,7 @@
                 "uglified": 322,
                 "compressed": 102.89282899921197
               },
-              "weight": 0.1268715524034673
+              "weight": 102.89282899921197
             }
           ],
           "sizes": {
@@ -97,7 +97,7 @@
             "uglified": 2538,
             "compressed": 810.9999999999999
           },
-          "weight": 1
+          "weight": 810.9999999999999
         }
       ],
       "sizes": {
@@ -105,7 +105,7 @@
         "uglified": 2538,
         "compressed": 810.9999999999999
       },
-      "rank": 0.26324926030513013
+      "weight": 810.9999999999999
     },
     {
       "label": "/assets/test-support.css (2.22 KB)",
@@ -122,14 +122,14 @@
                     "compressed": 2123.0700712589073
                   },
                   "label": "qunit.css (2.07 KB)",
-                  "weight": 0.9353842499109158
+                  "weight": 2123.0700712589073
                 }
               ],
               "sizes": {
                 "raw": 7875,
                 "compressed": 2123.0700712589073
               },
-              "weight": 0.9353842499109158
+              "weight": 2123.0700712589073
             },
             {
               "label": "ember-qunit (147 B)",
@@ -140,28 +140,28 @@
                     "compressed": 146.6603325415677
                   },
                   "label": "test-container-styles.css (147 B)",
-                  "weight": 0.06461575008908421
+                  "weight": 146.6603325415677
                 }
               ],
               "sizes": {
                 "raw": 544,
                 "compressed": 146.6603325415677
               },
-              "weight": 0.06461575008908421
+              "weight": 146.6603325415677
             }
           ],
           "sizes": {
             "raw": 8419,
             "compressed": 2269.730403800475
           },
-          "weight": 1
+          "weight": 2269.730403800475
         }
       ],
       "sizes": {
         "raw": 8419,
         "compressed": 2269.730403800475
       },
-      "rank": 0.7367507396948698
+      "weight": 2269.730403800475
     }
   ]
 }

--- a/test/fixtures/output/summary.js
+++ b/test/fixtures/output/summary.js
@@ -13,7 +13,7 @@
                 "compressed": 119.82860520094562
               },
               "label": "app.js (120 B)",
-              "weight": 0.14775413711583926
+              "weight": 119.82860520094562
             },
             {
               "label": "initializers (455 B)",
@@ -25,7 +25,7 @@
                     "compressed": 99.37785657998424
                   },
                   "label": "app-version.js (99 B)",
-                  "weight": 0.12253743104806937
+                  "weight": 99.37785657998424
                 },
                 {
                   "sizes": {
@@ -34,7 +34,7 @@
                     "compressed": 136.76438140267928
                   },
                   "label": "container-debug-adapter.js (137 B)",
-                  "weight": 0.1686367218282112
+                  "weight": 136.76438140267928
                 },
                 {
                   "sizes": {
@@ -43,7 +43,7 @@
                     "compressed": 218.56737588652481
                   },
                   "label": "export-application-global.js (219 B)",
-                  "weight": 0.2695035460992908
+                  "weight": 218.56737588652481
                 }
               ],
               "sizes": {
@@ -51,7 +51,7 @@
                 "uglified": 1423,
                 "compressed": 454.70961386918833
               },
-              "weight": 0.5606776989755714
+              "weight": 454.70961386918833
             },
             {
               "sizes": {
@@ -60,7 +60,7 @@
                 "compressed": 49.20961386918834
               },
               "label": "resolver.js (49 B)",
-              "weight": 0.06067769897557133
+              "weight": 49.20961386918834
             },
             {
               "sizes": {
@@ -69,7 +69,7 @@
                 "compressed": 84.35933806146572
               },
               "label": "router.js (84 B)",
-              "weight": 0.10401891252955084
+              "weight": 84.35933806146572
             },
             {
               "label": "templates (103 B)",
@@ -81,7 +81,7 @@
                     "compressed": 102.89282899921197
                   },
                   "label": "application.js (103 B)",
-                  "weight": 0.1268715524034673
+                  "weight": 102.89282899921197
                 }
               ],
               "sizes": {
@@ -89,7 +89,7 @@
                 "uglified": 322,
                 "compressed": 102.89282899921197
               },
-              "weight": 0.1268715524034673
+              "weight": 102.89282899921197
             }
           ],
           "sizes": {
@@ -97,7 +97,7 @@
             "uglified": 2538,
             "compressed": 810.9999999999999
           },
-          "weight": 1
+          "weight": 810.9999999999999
         }
       ],
       "sizes": {
@@ -105,7 +105,7 @@
         "uglified": 2538,
         "compressed": 810.9999999999999
       },
-      "rank": 0.26324926030513013
+      "weight": 810.9999999999999
     },
     {
       "label": "/assets/test-support.css (2.22 KB)",
@@ -122,14 +122,14 @@
                     "compressed": 2123.0700712589073
                   },
                   "label": "qunit.css (2.07 KB)",
-                  "weight": 0.9353842499109158
+                  "weight": 2123.0700712589073
                 }
               ],
               "sizes": {
                 "raw": 7875,
                 "compressed": 2123.0700712589073
               },
-              "weight": 0.9353842499109158
+              "weight": 2123.0700712589073
             },
             {
               "label": "ember-qunit (147 B)",
@@ -140,28 +140,28 @@
                     "compressed": 146.6603325415677
                   },
                   "label": "test-container-styles.css (147 B)",
-                  "weight": 0.06461575008908421
+                  "weight": 146.6603325415677
                 }
               ],
               "sizes": {
                 "raw": 544,
                 "compressed": 146.6603325415677
               },
-              "weight": 0.06461575008908421
+              "weight": 146.6603325415677
             }
           ],
           "sizes": {
             "raw": 8419,
             "compressed": 2269.730403800475
           },
-          "weight": 1
+          "weight": 2269.730403800475
         }
       ],
       "sizes": {
         "raw": 8419,
         "compressed": 2269.730403800475
       },
-      "rank": 0.7367507396948698
+      "weight": 2269.730403800475
     }
   ]
 }

--- a/test/unit/process-data-test.js
+++ b/test/unit/process-data-test.js
@@ -43,7 +43,7 @@ describe('process-data', function() {
             compressed: 1570
           },
           label: 'foo (1.53 KB)',
-          weight: 1,
+          weight: 1570,
           groups: [
             {
               sizes: {
@@ -52,7 +52,7 @@ describe('process-data', function() {
                 compressed: 70
               },
               label: 'bar.js (70 B)',
-              weight: 0.044585987261146494
+              weight: 70
             },
             {
               sizes: {
@@ -61,7 +61,7 @@ describe('process-data', function() {
                 compressed: 1500
               },
               label: 'baz.js (1.46 KB)',
-              weight: 0.9554140127388535
+              weight: 1500
             }
           ]
         }


### PR DESCRIPTION
Set `weight` property for root-level groups (the actual asset files) to their compressed size. Currently all files have the same size (in the foamtree visualization). This will render them proportionally to their size. webpack-bundle-analyzer seems to do the same.

Before:

![image](https://user-images.githubusercontent.com/1325249/32995851-d0ceefb2-cd7a-11e7-9007-7c43b5a2e6e2.png)

After: 

![image](https://user-images.githubusercontent.com/1325249/32995853-da540e82-cd7a-11e7-9d05-6baa8f430743.png)
