### PR TITLE
Expose createOutput function

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -6,7 +6,7 @@ const fs = require('fs');
 const path = require('path');
 const ora = require('ora');
 const concatStatsForPath = process.argv[2];
-const buildOuputSummary = require('./build-output-summary');
+const createOutput = require('./create-output');
 const summarizeAll = require('./summarize-all');
 
 const usage = "using concat-stats:\n" + "   node concat-stats <path-to-concat-stats-directory>";
@@ -23,19 +23,9 @@ summarizeAll(path.resolve(concatStatsForPath), function(entry) {
 });
 
 spinner.text = 'complete, checkout: ' + concatStatsForPath + '*.out.json';
-const cpr = require('cpr').cpr; //Back compat
 
-cpr(path.join(__dirname, '..', '/output'), concatStatsForPath, {
-  overwrite: true, //If the file exists, overwrite it
-}, (err/*, files*/) => {
-  spinner.stopAndPersist();
-  if (err) { console.error(err); return }
-  let summary = 'var SUMMARY = ' + JSON.stringify(buildOuputSummary(process.cwd() + '/concat-stats-for/'), null, 2);
-  let content = fs.readFileSync(concatStatsForPath + '/index.html', 'UTF8')
-    .replace('// INSERT SUMMARY //', summary);
+let content = createOutput(concatStatsForPath);
+fs.writeFileSync(concatStatsForPath + '/index.html', content);
 
-  fs.writeFileSync(concatStatsForPath + '/index.html', content);
-  console.log('visit file://' + process.cwd() + '/concat-stats-for/index.html');
-  //err - The error if any (err.list might be available with an array of errors for more detailed information)
-  //files - List of files that we copied
-});
+spinner.stopAndPersist();
+console.log('visit file://' + fs.realpathSync(concatStatsForPath) + '/index.html');

--- a/lib/create-output.js
+++ b/lib/create-output.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const buildOuputSummary = require('./build-output-summary');
+
+module.exports = function createOutput(concatStatsForPath) {
+  let summary = 'var SUMMARY = ' + JSON.stringify(buildOuputSummary(concatStatsForPath), null, 2);
+  return fs.readFileSync(path.join(__dirname, '..', '/output', 'index.html'), 'UTF8')
+    .replace('// INSERT SUMMARY //', summary);
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,9 +3,11 @@
 const buildOutputSummary = require('./build-output-summary');
 const summarize = require('./summarize');
 const summarizeAll = require('./summarize-all');
+const createOutput = require('./create-output');
 
 module.exports = {
   buildOutputSummary,
+  createOutput,
   summarize,
   summarizeAll
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   },
   "homepage": "https://github.com/stefanpenner/broccoli-concat-analyser#readme",
   "dependencies": {
-    "cpr": "^2.0.0",
     "filesize": "^3.3.0",
     "ora": "^0.3.0",
     "uglify-es": "^3.0.23",

--- a/yarn.lock
+++ b/yarn.lock
@@ -261,15 +261,6 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cpr@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/cpr/-/cpr-2.2.0.tgz#2dc6c87dfb78012489cdd994227628c320e9a17b"
-  dependencies:
-    graceful-fs "^4.1.5"
-    minimist "^1.2.0"
-    mkdirp "~0.5.1"
-    rimraf "^2.5.4"
-
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -557,7 +548,7 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.5, graceful-fs@^4.1.6:
+graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -851,11 +842,7 @@ minimist@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.1.0.tgz#99df657a52574c21c9057497df742790b2b4c0de"
 
-minimist@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
-mkdirp@0.5.1, mkdirp@^0.5.1, mkdirp@~0.5.1:
+mkdirp@0.5.1, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -1074,7 +1061,7 @@ restore-cursor@^2.0.0:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
 
-rimraf@^2.2.8, rimraf@^2.5.4:
+rimraf@^2.2.8:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
   dependencies:


### PR DESCRIPTION
This exposes a public `createOutput` function (for external consumption, e.g. addon), that returns the content of the final single-file output (as `cli.js` was doing it).