### PR TITLE
Parallelism using workerpool

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -16,16 +16,18 @@ if (!concatStatsForPath) {
   process.exit(1)
 }
 
-const spinner = ora('processing:').start();
-summarizeAll(path.resolve(concatStatsForPath), function(entry) {
-  spinner.text = 'processing: ' + concatStatsForPath + entry.relativePath + ' > ' + concatStatsForPath + path.basename(entry.relativePath, '.json') + '.out.json';
-  spinner.render();
-});
+const spinner = ora('processing...').start();
+summarizeAll(path.resolve(concatStatsForPath))
+  .then(() => {
+    spinner.text = 'complete, checkout: ' + concatStatsForPath + '*.out.json';
 
-spinner.text = 'complete, checkout: ' + concatStatsForPath + '*.out.json';
+    let content = createOutput(concatStatsForPath);
+    fs.writeFileSync(concatStatsForPath + '/index.html', content);
 
-let content = createOutput(concatStatsForPath);
-fs.writeFileSync(concatStatsForPath + '/index.html', content);
-
-spinner.stopAndPersist();
-console.log('visit file://' + fs.realpathSync(concatStatsForPath) + '/index.html');
+    spinner.stopAndPersist();
+    console.log('visit file://' + fs.realpathSync(concatStatsForPath) + '/index.html');
+  })
+  .catch(err => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/lib/summarize-all.js
+++ b/lib/summarize-all.js
@@ -1,22 +1,26 @@
 'use strict';
 
 const path = require('path');
-const summarize = require('./summarize');
 const walk = require('walk-sync');
+const workerpool = require('workerpool');
+
+const pool = workerpool.pool(path.join(__dirname, 'summarize-worker.js'));
 
 /**
  * Walk over all json files generated from broccoli-concat and write *.out.json containing size summary (uglified/compressed)
  * of all referenced files
  *
  * @param concatStatsForPath
- * @param cb
+ * @return {Promise}
  */
-module.exports = function summarizeAll(concatStatsForPath, cb) {
+module.exports = function summarizeAll(concatStatsForPath) {
   const entries = walk.entries(concatStatsForPath, { globs: ['*.json'], ignore: ['*.out.json'] });
-  entries.forEach(entry => {
-    if (cb) {
-      cb(entry);
-    }
-    summarize(path.join(concatStatsForPath, entry.relativePath));
-  });
+  return Promise.all(
+    entries.map(entry => pool.exec('summarize', [path.join(concatStatsForPath, entry.relativePath)]))
+  )
+    .catch((err) => {
+      pool.terminate();
+      throw err;
+    })
+    .then(() => pool.terminate());
 };

--- a/lib/summarize-worker.js
+++ b/lib/summarize-worker.js
@@ -1,0 +1,7 @@
+const workerpool = require('workerpool');
+const summarize = require('./summarize');
+
+// create a worker and register public functions
+workerpool.worker({
+  summarize
+});

--- a/lib/summarize.js
+++ b/lib/summarize.js
@@ -9,61 +9,65 @@ const zlib = require('zlib');
  * Given a single json file from broccoli-concat calculate the size summary (uglified/compressed) of all referenced files
  *
  * @param summaryPath
+ * @return {Promise}
  */
 module.exports = function summarize(summaryPath) {
-  let input = JSON.parse(fs.readFileSync(summaryPath, 'UTF8'));
-  let basename = path.basename(summaryPath, '.json');
-  let dirname = path.dirname(summaryPath);
+  return new Promise((resolve) => {
+    let input = JSON.parse(fs.readFileSync(summaryPath, 'UTF8'));
+    let basename = path.basename(summaryPath, '.json');
+    let dirname = path.dirname(summaryPath);
 
-  let fileNames = Object.keys(input.sizes);
-  let fileContents = {};
-  fileNames.forEach((filename) => fileContents[filename] = fs.readFileSync(path.join(dirname, basename, filename), 'UTF8'));
+    let fileNames = Object.keys(input.sizes);
+    let fileContents = {};
+    fileNames.forEach((filename) => fileContents[filename] = fs.readFileSync(path.join(dirname, basename, filename), 'UTF8'));
 
-  // we concatenate all files here to calculate the compressed size of the whole bundle. Calculating the compressed size
-  // of all files individually and adding this up will yield an inaccurate result, as gzip will do a much better job
-  // at compressing the whole bundle
-  // @todo This could be avoided if broccoli-concat would give us the concatenated file it has created, but the `outputFile`
-  // is currently a temporary file, which does not exist anymore when we run this, so we have to recreate it
-  let concatenatedContent = Object.keys(fileContents)
-    .map(filename => fileContents[filename])
-    .join('\n');
-  let compressed, baseSize;
-  let isUglifyable = /\.js$/.test(input.outputFile);
+    // we concatenate all files here to calculate the compressed size of the whole bundle. Calculating the compressed size
+    // of all files individually and adding this up will yield an inaccurate result, as gzip will do a much better job
+    // at compressing the whole bundle
+    // @todo This could be avoided if broccoli-concat would give us the concatenated file it has created, but the `outputFile`
+    // is currently a temporary file, which does not exist anymore when we run this, so we have to recreate it
+    let concatenatedContent = Object.keys(fileContents)
+      .map(filename => fileContents[filename])
+      .join('\n');
+    let compressed, baseSize;
+    let isUglifyable = /\.js$/.test(input.outputFile);
 
-  if (isUglifyable) {
-    let uglified = Uglify.minify(concatenatedContent);
-    compressed = zlib.deflateSync(uglified.code, { level: 9 });
-    baseSize = uglified.code.length;
-  } else {
-    compressed = zlib.deflateSync(concatenatedContent, { level: 9 });
-    baseSize = concatenatedContent.length;
-  }
-  let compressedSize = compressed.length;
+    if (isUglifyable) {
+      let uglified = Uglify.minify(concatenatedContent);
+      compressed = zlib.deflateSync(uglified.code, { level: 9 });
+      baseSize = uglified.code.length;
+    } else {
+      compressed = zlib.deflateSync(concatenatedContent, { level: 9 });
+      baseSize = concatenatedContent.length;
+    }
+    let compressedSize = compressed.length;
 
-  let files = fileNames.map(relativePath => {
-    let content = fileContents[relativePath];
-    let sizes = {
-      raw: content.length
+    let files = fileNames.map(relativePath => {
+      let content = fileContents[relativePath];
+      let sizes = {
+        raw: content.length
+      };
+
+      // assume the proportion of the compressed size is roughly the same as of the uglified/raw size
+      if (isUglifyable) {
+        sizes.uglified = Uglify.minify(content).code.length;
+        sizes.compressed = sizes.uglified / baseSize * compressedSize;
+      } else {
+        sizes.compressed = content.length / baseSize * compressedSize;
+      }
+
+      return {
+        relativePath,
+        sizes
+      }
+    });
+
+    let output = {
+      outputFile: input.outputFile,
+      files
     };
 
-    // assume the proportion of the compressed size is roughly the same as of the uglified/raw size
-    if (isUglifyable) {
-      sizes.uglified = Uglify.minify(content).code.length;
-      sizes.compressed = sizes.uglified / baseSize * compressedSize;
-    } else {
-      sizes.compressed = content.length / baseSize * compressedSize;
-    }
-
-    return {
-      relativePath,
-      sizes
-    }
+    fs.writeFileSync(path.join(dirname, basename + '.out.json'), JSON.stringify(output, null, 2));
+    resolve();
   });
-
-  let output = {
-    outputFile: input.outputFile,
-    files
-  };
-
-  fs.writeFileSync(path.join(dirname, basename + '.out.json'), JSON.stringify(output, null, 2));
 };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "filesize": "^3.3.0",
     "ora": "^0.3.0",
     "uglify-es": "^3.0.23",
-    "walk-sync": "^0.3.1"
+    "walk-sync": "^0.3.1",
+    "workerpool": "^2.3.1",
+    "zlib": "^1.0.5"
   },
   "devDependencies": {
     "chai": "^4.0.2",

--- a/test/integration/summarize-test.js
+++ b/test/integration/summarize-test.js
@@ -30,9 +30,8 @@ describe('summarize', function() {
       let outputFile = '1-test-app.js.out.json';
 
       copyFixtures(inputFile, inputFixturePath, tmpPath);
-      summarize(path.join(tmpPath, `${inputFile}.json`));
-
-      expect(file(path.join(tmpPath, outputFile))).to.equal(file(path.join(outputFixturePath, outputFile)));
+      return summarize(path.join(tmpPath, `${inputFile}.json`))
+        .then(() => expect(file(path.join(tmpPath, outputFile))).to.equal(file(path.join(outputFixturePath, outputFile))));
     });
 
   });
@@ -43,12 +42,13 @@ describe('summarize', function() {
       let inputFiles = ['1-test-app.js', '3-vendor.css', '8-test-support.css'];
 
       copyFixtures(inputFiles, inputFixturePath, tmpPath);
-      summarizeAll(tmpPath);
-
-      inputFiles.forEach((inputFile) => {
-        let outputFile = `${inputFile}.out.json`;
-        expect(file(path.join(tmpPath, outputFile))).to.equal(file(path.join(outputFixturePath, outputFile)));
-      });
+      return summarizeAll(tmpPath)
+        .then(() => {
+          inputFiles.forEach((inputFile) => {
+            let outputFile = `${inputFile}.out.json`;
+            expect(file(path.join(tmpPath, outputFile))).to.equal(file(path.join(outputFixturePath, outputFile)));
+          });
+        });
     });
 
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -893,7 +893,7 @@ oauth-sign@~0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
 
-object-assign@^4.0.1:
+object-assign@4.1.1, object-assign@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -1283,6 +1283,12 @@ wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
 
+workerpool@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-2.3.1.tgz#6872d3a749dd820d42b8390abaac20fb14ce4c81"
+  dependencies:
+    object-assign "4.1.1"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -1298,3 +1304,7 @@ yargs@~1.2.6:
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-1.2.6.tgz#9c7b4a82fd5d595b2bf17ab6dcc43135432fe34b"
   dependencies:
     minimist "^0.1.0"
+
+zlib@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/zlib/-/zlib-1.0.5.tgz#6e7c972fc371c645a6afb03ab14769def114fcc0"


### PR DESCRIPTION
Closes #11 

Worth noting:
* this changes to signature of some public (exposed in index.js) function to return a Promise, so again kind of a breaking change. I don't know if this is used anywhere besides my WIP addon though, so not sure if we have to bump the major version. I guess we can ignore this until these exposed functions have become more "official" (addon is published, functions are documented)?
* although the `summarize` function is not really working asynchronously, I nevertheless changed it also to return a Promise, so we can change the implementation a bit under the hood (like not using the `...Sync()` node functions or so, if that makes sense)
* I removed some of the spinner feedback ("processing: &lt;bundleName&gt; ...") from the CLI, as it did not make so much sense when bundles are processed in parallel. (the messages all show up at once, or rather only the last message is visible as the previous are replaced)