### PR TITLE
Refactor summarize() to work async

### DIFF
--- a/lib/summarize.js
+++ b/lib/summarize.js
@@ -1,9 +1,19 @@
 'use strict';
 
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 const Uglify = require('uglify-es');
 const zlib = require('zlib');
+const pify = require('pify');
+
+function uglify(content) {
+  let uglified = Uglify.minify(content);
+  return Promise.resolve(uglified.code);
+}
+
+function compress(content) {
+  return pify(zlib.deflate)(content, { level: 9 });
+}
 
 /**
  * Given a single json file from broccoli-concat calculate the size summary (uglified/compressed) of all referenced files
@@ -12,62 +22,70 @@ const zlib = require('zlib');
  * @return {Promise}
  */
 module.exports = function summarize(summaryPath) {
-  return new Promise((resolve) => {
-    let input = JSON.parse(fs.readFileSync(summaryPath, 'UTF8'));
-    let basename = path.basename(summaryPath, '.json');
-    let dirname = path.dirname(summaryPath);
+  let input = JSON.parse(fs.readFileSync(summaryPath, 'UTF8'));
+  let basename = path.basename(summaryPath, '.json');
+  let dirname = path.dirname(summaryPath);
 
-    let fileNames = Object.keys(input.sizes);
-    let fileContents = {};
-    fileNames.forEach((filename) => fileContents[filename] = fs.readFileSync(path.join(dirname, basename, filename), 'UTF8'));
+  let fileNames = Object.keys(input.sizes);
+  let fileContents = {};
+  fileNames.forEach((filename) => fileContents[filename] = fs.readFileSync(path.join(dirname, basename, filename), 'UTF8'));
 
-    // we concatenate all files here to calculate the compressed size of the whole bundle. Calculating the compressed size
-    // of all files individually and adding this up will yield an inaccurate result, as gzip will do a much better job
-    // at compressing the whole bundle
-    // @todo This could be avoided if broccoli-concat would give us the concatenated file it has created, but the `outputFile`
-    // is currently a temporary file, which does not exist anymore when we run this, so we have to recreate it
-    let concatenatedContent = Object.keys(fileContents)
-      .map(filename => fileContents[filename])
-      .join('\n');
-    let compressed, baseSize;
-    let isUglifyable = /\.js$/.test(input.outputFile);
+  // we concatenate all files here to calculate the compressed size of the whole bundle. Calculating the compressed size
+  // of all files individually and adding this up will yield an inaccurate result, as gzip will do a much better job
+  // at compressing the whole bundle
+  // @todo This could be avoided if broccoli-concat would give us the concatenated file it has created, but the `outputFile`
+  // is currently a temporary file, which does not exist anymore when we run this, so we have to recreate it
+  let concatenatedContent = Object.keys(fileContents)
+    .map(filename => fileContents[filename])
+    .join('\n');
+  let isUglifyable = /\.js$/.test(input.outputFile);
 
-    if (isUglifyable) {
-      let uglified = Uglify.minify(concatenatedContent);
-      compressed = zlib.deflateSync(uglified.code, { level: 9 });
-      baseSize = uglified.code.length;
-    } else {
-      compressed = zlib.deflateSync(concatenatedContent, { level: 9 });
-      baseSize = concatenatedContent.length;
-    }
-    let compressedSize = compressed.length;
+  return Promise.resolve()
+    .then(() => {
+      if (isUglifyable) {
+        return uglify(concatenatedContent);
+      } else {
+        return concatenatedContent;
+      }
+    })
+    .then(content => {
+      return compress(content)
+        .then(compressed => ({
+          baseSize: content.length,
+          compressedSize: compressed.length
+        }))
+    })
+    .then(({ compressedSize, baseSize }) => {
+      return Promise.all(fileNames.map(relativePath => {
+        let content = fileContents[relativePath];
 
-    let files = fileNames.map(relativePath => {
-      let content = fileContents[relativePath];
-      let sizes = {
-        raw: content.length
+        return Promise.resolve()
+          .then(() => {
+            if (isUglifyable) {
+              return uglify(content)
+            }
+          })
+          .then((uglified) => {
+            let uncompressedSize = uglified ? uglified.length : content.length;
+
+            // assume the proportion of the compressed size is roughly the same as of the uglified/raw size
+            return {
+              relativePath,
+              sizes: {
+                raw: content.length,
+                uglified: uglified ? uglified.length : undefined,
+                compressed: uncompressedSize / baseSize * compressedSize
+              }
+            };
+          });
+      }));
+    })
+    .then((files) => {
+      let output = {
+        outputFile: input.outputFile,
+        files
       };
 
-      // assume the proportion of the compressed size is roughly the same as of the uglified/raw size
-      if (isUglifyable) {
-        sizes.uglified = Uglify.minify(content).code.length;
-        sizes.compressed = sizes.uglified / baseSize * compressedSize;
-      } else {
-        sizes.compressed = content.length / baseSize * compressedSize;
-      }
-
-      return {
-        relativePath,
-        sizes
-      }
+      return fs.writeFile(path.join(dirname, basename + '.out.json'), JSON.stringify(output, null, 2));
     });
-
-    let output = {
-      outputFile: input.outputFile,
-      files
-    };
-
-    fs.writeFileSync(path.join(dirname, basename + '.out.json'), JSON.stringify(output, null, 2));
-    resolve();
-  });
 };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   "homepage": "https://github.com/stefanpenner/broccoli-concat-analyser#readme",
   "dependencies": {
     "filesize": "^3.3.0",
+    "fs-extra": "^4.0.2",
     "ora": "^0.3.0",
+    "pify": "^4.0.0",
     "uglify-es": "^3.0.23",
     "walk-sync": "^0.3.1",
     "workerpool": "^2.3.1",
@@ -30,7 +32,6 @@
   "devDependencies": {
     "chai": "^4.0.2",
     "chai-files": "^1.4.0",
-    "fs-extra": "^4.0.2",
     "html-validator": "^3.0.6",
     "mocha": "^3.4.2",
     "mocha-eslint": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -957,6 +957,10 @@ pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
 
+pify@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.0.tgz#db04c982b632fd0df9090d14aaf1c8413cadb695"
+
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"


### PR DESCRIPTION
The function was already returning a Promise, but still using a lot of sync APIs. Refactored this to use Promises and async APIs internally.

*Originally the intention was to also offload the Uglify call to a workerpool (thus requiring async processing). This was to not only analyze the whole bundled file in a worker, but also the uglification of each contained module, in order to get some better CPU utilization. But in practice this did not yield any noticeable improvements, so skipping this...* 