### PR TITLE
Add instructions to open index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ produces:
 2. `CONCAT_STATS=true ember s`
 3. `broccoli-concat-analyser ./concat-stats-for`
 4. look at .out.json files in ./concat-stats-for for the process output
+5. open ./concat-stats-for/index.html in any browser for the foamtree interactive map
 
 ## Features
 


### PR DESCRIPTION
Adding this last step might save some time to others in the future.

I didn't notice there was an index.html file

It might be because it's late, but I had a hard time finding how to get the interactive map to show (my first time using this), I even downloaded the foamtree source o.O